### PR TITLE
Update system package dependencies, libegl-dev and libopengl0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ USER root
 RUN apt-get update && apt-get install -y \
         libgl1 \
         libglib2.0-0 \
+        libegl-dev \
+        libopengl0 \
         libsm6 \
         libxext6 \
         libxrender1 \


### PR DESCRIPTION
Update Dockerfile to reflect dependency on system packages libegl-dev and libopengl0, which apparently aren't included with the conda install of opencv 4.9.0.