### PR TITLE
fix YOLO object counter incrementation

### DIFF
--- a/yolo_processing.py
+++ b/yolo_processing.py
@@ -116,7 +116,7 @@ def yolo_process_image(
 
             # Update object metrics
             increment_seal_object_counter(
-                ModelFramework.TF.name,
+                ModelFramework.YOLO.name,
                 model,
                 version
             )


### PR DESCRIPTION
Fixes copy-pasted error during YOLO object counter incrementation. Caused YOLO model object detections to be counted against the tensorflow models counters.